### PR TITLE
defer js

### DIFF
--- a/mayan/apps/appearance/templates/appearance/root.html
+++ b/mayan/apps/appearance/templates/appearance/root.html
@@ -99,12 +99,11 @@
         <script src="{% static 'appearance/js/mayan_image.js' %}" type="text/javascript"></script>
         <script src="{% static 'appearance/js/partial_navigation.js' %}" type="text/javascript"></script>
 
-        <!-- only loading critical js -->
         <script src="{% static 'appearance/js/critical_js_onload.js' %}" data-auto-replace-svg="nest" type="text/javascript"></script>
-        <!-- then loading rest fontawesome js -->
+
         <script async src="{% static 'appearance/node_modules/@fortawesome/fontawesome-free/js/all.min.js' %}" data-auto-replace-svg="nest" type="text/javascript"></script>
         <script>
-            
+
         <script>
             {# Transfer variable from Django to javascript #}
             var initialURL = '{% url home_view %}';


### PR DESCRIPTION
One reason for the delay in FCP was the large fontawesome js file. Critical js from the file was minimal, so I loaded the small number of critical js scripts locally and the rest asynchronously (https://flaviocopes.com/javascript-async-defer/ )

the performance score was improved from 30 to 47, up by 17 points.
(fixes #8)